### PR TITLE
Modal locking (and added ability to pass element directly to modal constructor)

### DIFF
--- a/src/components/modals/modals.js
+++ b/src/components/modals/modals.js
@@ -1,10 +1,19 @@
-var dh2oModal = function (modalId, autoShow, callback = null) {
-  modalId = modalId || false
-  autoShow = autoShow || false
-  if (!modalId) { throw new Error('Must pass a modal id') }
+var dh2oModal = function (idOrElement = false, autoShow = false, callback = null) {
+  if (!idOrElement) { throw new Error('You must pass in an id or a DOM element') }
 
-  var modal = document.getElementById(modalId)
-  if (!modal) { throw new Error('Could not find modal. Please make sure you pass an id of a modal that exists') }
+
+  let modal
+  if (typeof idOrElement === 'string') {
+    // it's an id:
+    modal = document.getElementById(modalId)
+    if (!modal) { throw new Error('Could not find modal. Please make sure you pass an id of a modal that exists') }
+  }
+  else {
+    // it's a DOM element (hopefully):
+    modal = idOrElement
+    if (!modal) { throw new Error(`Expected a modal element, but got ${modal}`) }
+  }
+
   var closeName = 'modal-close'
 
   // Check to make sure modal content exist
@@ -45,12 +54,31 @@ var dh2oModal = function (modalId, autoShow, callback = null) {
     if (callback) { callback(true) }
   }
   modal.hide = function () {
+    if (modal.isLocked) {
+      // you can't hide the modal while it's locked -- you have to unlock() it
+      // first
+      return
+    }
+
     modal.classList.remove('animate-in')
     modal.classList.add('animate-out')
     setTimeout(function () {
       modal.classList.remove('animate-out')
       if (callback) { callback(false) }
     }, 300)
+  }
+
+  modal.isLocked = false
+
+  // call this to prevent the user from closing the modal. Note that hide()
+  // won't work when the modal is locked.
+  modal.lock = function () {
+    modal.isLocked = true
+    modal.querySelector('.modal-close-x').innerHTML = ''
+  }
+  modal.unlock = function () {
+    modal.isLocked = false
+    modal.querySelector('.modal-close-x').innerHTML = 'X'
   }
 
   // Show modal
@@ -109,18 +137,6 @@ document.onkeydown = function (evt) {
     if (modals.length > 0) {
       if (modals[modals.length - 1].hide) {
         modals[modals.length - 1].hide()
-      }
-    }
-  }
-
-  // If you hit enter find a modal-enter class and click it
-  if (isEnter) {
-    modals = document.querySelectorAll('.dh2o-modal.animate-in')
-    if (modals.length > 0) {
-      var modal = modals[modals.length - 1]
-      var enterer = modal.querySelector('.modal-enter')
-      if (enterer) {
-        enterer.click()
       }
     }
   }

--- a/src/docs/components/modals.vue
+++ b/src/docs/components/modals.vue
@@ -2,11 +2,19 @@
   import dh2oModal from 'dh2o-atlantis/components/modals/modals.js'
 
   export default {
+    mounted () {
+      // note that you can create modals without an ID if you use a direct
+      // reference to the DOM element:
+      dh2oModal(this.$refs.modalLock)
+    },
+
     data () {
       return {
-        isModalJsShowing: false
+        isModalJsShowing: false,
+        isModalLockLocked: false
       }
     },
+
     methods: {
       applyModal () {
         var text = '<h1>Great job on clicking a button. What?!?! Do you want a medal or something?</h1>'
@@ -19,6 +27,21 @@
         dh2oModal('modalJs', true, (isShowing) => {
           this.isModalJsShowing = isShowing
         })
+      },
+
+      showModalLock () {
+        this.$refs.modalLock.show()
+        this.lock()
+      },
+
+      lock() {
+        this.$refs.modalLock.lock()
+        this.isModalLockLocked = true
+      },
+
+      unlock () {
+        this.$refs.modalLock.unlock()
+        this.isModalLockLocked = false
       }
     }
   }
@@ -296,6 +319,42 @@
               modal.show()
               // or
               modal.hide()
+            </code>
+          </pre>
+        </div>
+      </div>
+
+      <div class="widget">
+        <header><h2>Locking</h2></header>
+        <div class="body">
+          <p>Use <code class="language-js">modal.lock()</code> and <code class="language-js">modal.unlock()</code>
+          to prevent a user from closing the modal.</p>
+
+          <p>Note that this <strong>also</strong> prevents you from closing the modal manually with <code class="language-js">modal.hide()</code>.
+          If you lock the modal, you must call <code class="language-js">modal.unlock()</code> before hiding it.
+
+          <div class="btn secondary" @click="showModalLock">
+            Click me to open a locked modal!
+          </div>
+
+          <div ref="modalLock" class="dh2o-modal">
+            <div class="modal-content" style="width: 300px;">
+              <div class="modal-body">
+                <p>You have to unlock the modal before you can close it</p>
+                <p>The modal <strong>{{ isModalLockLocked ? 'is' : 'is not'}}</strong> currently locked.</p>
+                <button class="btn primary" @click="lock">Lock</button>
+                <button class="btn primary" @click="unlock">Unlock</button>
+              </div>
+            </div>
+          </div>
+          <pre>
+            <code class="language-js">
+              let modal = dh2oModal('modalId')
+              modal.lock()
+              // the modal is now unclosable
+
+              modal.unlock()
+              // the modal can now be closed
             </code>
           </pre>
         </div>


### PR DESCRIPTION
We need this for the Save/Save As/Rename/Optimize modals in kraken.

<img width="1304" alt="screen shot 2017-08-31 at 5 13 46 pm" src="https://user-images.githubusercontent.com/1735971/29947586-f6c76cca-8e6f-11e7-81ce-78056319599e.png">
